### PR TITLE
fix AddressSanitizer: alloc-dealloc-mismatch

### DIFF
--- a/alignment/seqregion.cpp
+++ b/alignment/seqregion.cpp
@@ -57,7 +57,7 @@ SeqRegion::~SeqRegion()
 {
     if (likelihood)
     {
-        delete likelihood;
+        delete[] likelihood;
         likelihood = NULL;
     }
 }
@@ -158,7 +158,7 @@ void SeqRegion::computeLhAmbiguity(IntVector &entries)
     
     // init likelihood
     if (likelihood)
-        delete likelihood;
+        delete[] likelihood;
     likelihood = new RealNumType[entries.size()];
     
     for (StateType i = 0; i < (StateType) entries.size(); ++i)


### PR DESCRIPTION
fixes a fatal error when running addressSanitizer on cmaple
```
-- Build files have been written to: /buffer/ag_bsc/build/cmaple/cmake-build-debug
[19/19] Linking CXX executable cmaple
Reading a Diff file
=================================================================
==3052470==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x60300009a510
    #0 0x7ff709e04467 in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x564de36796d7 in SeqRegion::~SeqRegion() ../alignment/seqregion.cpp:60
    #2 0x564de36796d7 in SeqRegion::~SeqRegion() ../alignment/seqregion.cpp:63                                                                                                                                    #3 0x564de367c7cc in SeqRegions::deleteRegions() ../alignment/seqregions.cpp:32
    #4 0x564de367c9d8 in SeqRegions::~SeqRegions() ../alignment/seqregions.cpp:26
    #5 0x564de36cc21f in Tree::placeNewSample(Node*, SeqRegions*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, bool, double, double, Node*, double*, std::vector<s
td::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > >&, double, double, double) ../tree/tree.cpp:2345
    #6 0x564de36f7064 in CMaple::buildInitialTree() ../main/cmaple.cpp:152
    #7 0x564de36fbab7 in CMaple::doInference() ../main/cmaple.cpp:276
    #8 0x564de36fbab7 in runCMaple(Params&) ../main/cmaple.cpp:325
    #9 0x564de365ea81 in main ../main/main.cpp:45
    #10 0x7ff709830d09 in __libc_start_main ../csu/libc-start.c:308
    #11 0x564de365e919 in _start (/buffer/ag_bsc/build/cmaple/cmake-build-debug/cmaple+0x25919)

0x60300009a510 is located 0 bytes inside of 32-byte region [0x60300009a510,0x60300009a530)
allocated by thread T0 here:
    #0 0x7ff709e037a7 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:102
    #1 0x564de3680dc0 in SeqRegions::mergeTwoLowers(SeqRegions*&, double, SeqRegions*, double, Alignment*, Model*, double, double*, bool) ../alignment/seqregions.cpp:1024

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch ../../../../src/libsanitizer/asan/asan_new_delete.cpp:172 in operator delete(void*, unsigned long)
==3052470==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==3052470==ABORTING

```

This is caused by calling `delete x` on an x which is actually an array.